### PR TITLE
[fix] Define utf-8-sig encoding on open() function

### DIFF
--- a/CSVLib/__init__.py
+++ b/CSVLib/__init__.py
@@ -5,7 +5,7 @@ class CSVLib(object):
 
     """ Reads a given CSV file and returns it as a dictionary. """
     def read_csv_as_dictionary(self, filename, key_column, value_columns, delimiter='\n'):
-        file = open(filename, 'r')
+        file = open(filename, 'r', encoding='utf-8-sig')
         csvfile = csv.DictReader(file, delimiter=delimiter)
         output = {}
         for row in csvfile:
@@ -22,7 +22,7 @@ class CSVLib(object):
 
     """ Reads a given CSV file and returns it as a list containing all rows as list. """
     def read_csv_as_list(self, filename, delimiter='\n'):
-        file = open(filename, 'r')
+        file = open(filename, 'r', encoding='utf-8-sig')
         csvfile = csv.reader(file, delimiter=delimiter)
         output = []
         for row in csvfile:
@@ -32,7 +32,7 @@ class CSVLib(object):
 
     """ Reads a given CSV file and returns it as a single list containing all values. """
     def read_csv_as_single_list(self, filename, delimiter='\n'):
-        file = open(filename, 'r')
+        file = open(filename, 'r', encoding='utf-8-sig')
         csvfile = csv.reader(file, delimiter=delimiter)
         output = []
         for row in csvfile:


### PR DESCRIPTION
With a CSV file with ; delimiter and columns with this names : id;name;groupPath;properties; etc...
I had this weird `\ufeff` at the beginning of the file
Adding an utf8 encoding on open file function fixed my issue

```
${CSVGlobalList}    CSVLib.Read Csv As List    ${CSVfile}    delimiter=;
16:30:26.710 	INFO 	${CSVGlobalList} = [['\ufeffid', 'name', 'groupPath', 'properties', 'tags' ...

```
Instead of
`16:34:42.261 	INFO 	${CSVGlobalList} = [['id', 'name', 'groupPath', 'properties', 'tags' ...`